### PR TITLE
Fix Flux Kontext ReferenceLatent and ControlNet shape mismatch

### DIFF
--- a/nodes/patch_lib/FluxPatch.py
+++ b/nodes/patch_lib/FluxPatch.py
@@ -270,6 +270,11 @@ def double_block_and_control_replace(i, block, img, txt=None, vec=None, pe=None,
         if i < len(control_i):
             add = control_i[i]
             if add is not None:
+                if img.shape[1] != add.shape[1]:
+                    padding_size = img.shape[1] - add.shape[1]
+                    if padding_size > 0:
+                        padding = torch.zeros(add.shape[0], padding_size, add.shape[2], device=add.device, dtype=add.dtype)
+                        add = torch.cat([add, padding], dim=1)
                 img += add
 
     del blocks_replace


### PR DESCRIPTION
### Summary

Allows to use Flux ControlNet with Flux Kontext ReferenceLatent

---

### Description

Currently there's a shape mismatch in the **[forward_orig](https://github.com/comfyanonymous/ComfyUI/blob/03895dea7c4a6cc93fa362cd11ca450217d74b13/comfy/ldm/flux/model.py#L160)** method due to conditioning concatentation for Flux Kontext.
<details><summary>Sources</summary>
<p>
Error

<img width="1280" height="705" alt="image" src="https://github.com/user-attachments/assets/4050d33e-08c5-48d8-a434-592b3bf6edb0" />
Kontext conditioning concat

<img width="1580" height="676" alt="image" src="https://github.com/user-attachments/assets/03fc7598-8e8c-4042-99b7-24abd392cc5f" />
</p>
</details> 

This PR introduces a fix that pads **img** with zeroes along the 1st dim to match the shape.  

This change is local but potentially can cause issues if the input shapes mismatch due to different reason than kontext conditioing, e.g. due to some errors.  


---

### Example workflow to reproduce behaviour
[FLUX_KONTEXT_REFERENCE_PR.json](https://github.com/user-attachments/files/21588986/FLUX_KONTEXT_REFERENCE_PR.json)

<img width="2693" height="1520" alt="workflow(361)" src="https://github.com/user-attachments/assets/59ccb0ec-7cc8-4221-9633-c7f80b35caba" />

---

### Links

[ComfyUI Pull Request](https://github.com/comfyanonymous/ComfyUI/pull/9180)